### PR TITLE
Implementing eq.rewrite(Add)

### DIFF
--- a/algebra_with_sympy/algebraic_equation.py
+++ b/algebra_with_sympy/algebraic_equation.py
@@ -507,7 +507,7 @@ class Equation(Basic, EvalfMixin):
     def dorhs(self):
         return self._sides(self, side='rhs')
     
-    def _eval_rewrite_as_Add(self, *args, **kwargs):
+    def _eval_rewrite(self, rule, args, **kwargs):
         """Return Equation(L, R) as Equation(L - R, 0) or as L - R.
 
         Parameters
@@ -541,25 +541,26 @@ class Equation(Basic, EvalfMixin):
         >>> eq.rewrite(Add, eqn=False, evaluate=False).args
         (b, x, b, -x)
         """
-        # NOTE: the code about `evaluate` is very similar to
-        # sympy.core.relational.Equality._eval_rewrite_as_Add
-        eqn = kwargs.pop("eqn", True)
-        evaluate = kwargs.get('evaluate', True)
-        L, R = args
-        if evaluate:
-            # allow cancellation of args
-            expr = L - R
-        else:
-            args = Add.make_args(L) + Add.make_args(-R)
-            if evaluate is None:
-                # no cancellation, but canonical
-                expr = _unevaluated_Add(*args)
+        if rule == Add:
+            # NOTE: the code about `evaluate` is very similar to
+            # sympy.core.relational.Equality._eval_rewrite_as_Add
+            eqn = kwargs.pop("eqn", True)
+            evaluate = kwargs.get('evaluate', True)
+            L, R = args
+            if evaluate:
+                # allow cancellation of args
+                expr = L - R
             else:
-                # no cancellation, not canonical
-                expr = Add._from_args(args)
-        if eqn:
-            return self.func(expr, 0)
-        return expr
+                args = Add.make_args(L) + Add.make_args(-R)
+                if evaluate is None:
+                    # no cancellation, but canonical
+                    expr = _unevaluated_Add(*args)
+                else:
+                    # no cancellation, not canonical
+                    expr = Add._from_args(args)
+            if eqn:
+                return self.func(expr, 0)
+            return expr
 
     #####
     # Overrides of binary math operations

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -1,4 +1,4 @@
-from sympy import symbols, integrate, simplify, expand, factor, Integral
+from sympy import symbols, integrate, simplify, expand, factor, Integral, Add
 from sympy import diff, FiniteSet, Equality, Function, functions, Matrix, S
 from sympy import sin, cos, log, exp
 from .algebraic_equation import solve, collect, Equation, Eqn, sqrt, root
@@ -143,7 +143,6 @@ def test_helper_functions():
     assert sqrt(Eqn(a,b/c)) == Equation(sqrt(a), sqrt(b/c))
 
 
-
 def test_apply_syntax():
     a, b, c, x = symbols('a b c x')
     tsteqn = Equation(a, b/c)
@@ -162,3 +161,13 @@ def test_do_syntax():
     assert poly.dorhs.collect(x) == Eqn(poly.lhs, poly.rhs.collect(x))
     assert poly.dolhs.collect(x) == Eqn(poly.lhs.collect(x), poly.rhs)
     assert poly.do.collect(x) == Eqn(poly.lhs.collect(x), poly.rhs.collect(x))
+
+
+def test_rewrite_add():
+    b, x = symbols("x, b")
+    eq = Equation(x + b, x - b)
+    assert eq.rewrite(Add) == Equation(2 * b, 0)
+    assert set(eq.rewrite(Add, evaluate=None).lhs.args) == set((b, x, b, -x))
+    assert set(eq.rewrite(Add, evaluate=False).lhs.args) == set((b, x, b, -x))
+    assert eq.rewrite(Add, eqn=False) == 2 * b
+    assert set(eq.rewrite(Add, eqn=False, evaluate=False).args) == set((b, x, b, -x))

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -177,7 +177,9 @@ def test_rewrite():
     eq = Equation(exp(I*x),cos(x) + I*sin(x))
 
     # NOTE: right now I must use `sexp` otherwise the test is going to fail.
-    # I absolutely have no idea what's going on.
+    # I absolutely have no idea what's going on. Interesting to note that this
+    # only happens with pytest. On real life (inside Jupyter notebook),
+    # everything works as expected
     from sympy import exp as sexp
     assert eq.rewrite(exp) == Equation(exp(I*x), sexp(I*x))
     assert eq.rewrite(Add) == Equation(exp(I*x) - I*sin(x) - cos(x), 0)

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -1,6 +1,6 @@
 from sympy import symbols, integrate, simplify, expand, factor, Integral, Add
 from sympy import diff, FiniteSet, Equality, Function, functions, Matrix, S
-from sympy import sin, cos, log, exp
+from sympy import sin, cos, log, exp, I
 from .algebraic_equation import solve, collect, Equation, Eqn, sqrt, root
 from .algebraic_equation import algwsym_config
 from .algebraic_equation import EqnFunction, str_to_extend_sympy_func
@@ -171,3 +171,13 @@ def test_rewrite_add():
     assert set(eq.rewrite(Add, evaluate=False).lhs.args) == set((b, x, b, -x))
     assert eq.rewrite(Add, eqn=False) == 2 * b
     assert set(eq.rewrite(Add, eqn=False, evaluate=False).args) == set((b, x, b, -x))
+
+def test_rewrite():
+    x = symbols("x")
+    eq = Equation(exp(I*x),cos(x) + I*sin(x))
+
+    # NOTE: right now I must use `sexp` otherwise the test is going to fail.
+    # I absolutely have no idea what's going on.
+    from sympy import exp as sexp
+    assert eq.rewrite(exp) == Equation(exp(I*x), sexp(I*x))
+    assert eq.rewrite(Add) == Equation(exp(I*x) - I*sin(x) - cos(x), 0)


### PR DESCRIPTION
There are occasions in which it is useful to rewrite `Equation(L, R)` either as `Equation(L-R, 0)`
or as a symbolic expression `L-R`. For example:

```
from sympy import *
from algebra_with_sympy import Equation
DT = symbols(r"\Delta{T}")
alc, als = symbols("alpha_c, alpha_s")
sc, ss = symbols("sigma_c, sigma_s")
E, Ac, As = symbols("E, A_c, A_s")
eq = Equation(alc * DT + sc / E, als * DT - Ac * sc / (As * E))

# with the new feature
eq.rewrite(Add).collect(sc).collect(DT)

# old way: longer to type
Equation(eq.lhs - eq.rhs, 0).collect(sc).collect(DT)
```

The implementation borrowed code from `sympy.core.relational.Equality._eval_rewrite_as_Add`.
This should provide a more consistent user-experience for people that are used to such functionality.