### PR TITLE
Implemented eq1.subs(eq2)

### DIFF
--- a/algebra_with_sympy/algebraic_equation.py
+++ b/algebra_with_sympy/algebraic_equation.py
@@ -581,6 +581,11 @@ class Equation(Basic, EvalfMixin):
         new_args = args
         if all(isinstance(a, self.func) for a in args):
             new_args = [{a.args[0]: a.args[1] for a in args}]
+        elif (len(args) == 1) and all(isinstance(a, self.func) for a in args):
+            raise TypeError("You passed into `subs` a list of elements of "
+                "type `Equation`, but this is not supported. Please, consider "
+                "unpacking the list with `.subs(*eq_list)` or select your "
+                "equations from the list and use `.subs(eq1, eq2, ...)`.")
         elif any(isinstance(a, self.func) for a in args):
             raise ValueError("`args` contains one or more Equation and some "
                 "other data type. This mode of operation is not supported. "

--- a/algebra_with_sympy/algebraic_equation.py
+++ b/algebra_with_sympy/algebraic_equation.py
@@ -521,60 +521,6 @@ class Equation(Basic, EvalfMixin):
     def dorhs(self):
         return self._sides(self, side='rhs')
     
-    def _eval_rewrite_as_Add(self, *args, **kwargs):
-        """Return Equation(L, R) as Equation(L - R, 0) or as L - R.
-
-        Parameters
-        ==========
-
-        evaluate : bool, optional
-            Control the evaluation of the result. If `evaluate=None` then
-            terms in L and R will not cancel but they will be listed in
-            canonical order; otherwise non-canonical args will be returned.
-            Default to True.
-        
-        eqn : bool, optional
-            Control the returned type. If `eqn=True`, then Equation(L - R, 0)
-            is returned. Otherwise, the L - R symbolic expression is returned.
-            Default to True.
-
-        Examples
-        ========
-        >>> from sympy import Add
-        >>> from sympy.abc import b, x
-        >>> from algebra_with_sympy import Equation
-        >>> eq = Equation(x + b, x - b)
-        >>> eq.rewrite(Add)
-        Equation(2*b, 0)
-        >>> eq.rewrite(Add, evaluate=None).lhs.args
-        (b, x, b, -x)
-        >>> eq.rewrite(Add, evaluate=False).lhs.args
-        (b, x, b, -x)
-        >>> eq.rewrite(Add, eqn=False)
-        2*b
-        >>> eq.rewrite(Add, eqn=False, evaluate=False).args
-        (b, x, b, -x)
-        """
-        # NOTE: the code about `evaluate` is very similar to
-        # sympy.core.relational.Equality._eval_rewrite_as_Add
-        eqn = kwargs.pop("eqn", True)
-        evaluate = kwargs.get('evaluate', True)
-        L, R = args
-        if evaluate:
-            # allow cancellation of args
-            expr = L - R
-        else:
-            args = Add.make_args(L) + Add.make_args(-R)
-            if evaluate is None:
-                # no cancellation, but canonical
-                expr = _unevaluated_Add(*args)
-            else:
-                # no cancellation, not canonical
-                expr = Add._from_args(args)
-        if eqn:
-            return self.func(expr, 0)
-        return expr
-    
     def subs(self, *args, **kwargs):
         """Substitutes old for new in an equation after sympifying args.
     

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -1,4 +1,4 @@
-from sympy import symbols, integrate, simplify, expand, factor, Integral
+from sympy import symbols, integrate, simplify, expand, factor, Integral, Add
 from sympy import diff, FiniteSet, Equality, Function, functions, Matrix, S
 from sympy import sin, cos, log, exp
 from .algebraic_equation import solve, collect, Equation, Eqn, sqrt, root
@@ -143,7 +143,6 @@ def test_helper_functions():
     assert sqrt(Eqn(a,b/c)) == Equation(sqrt(a), sqrt(b/c))
 
 
-
 def test_apply_syntax():
     a, b, c, x = symbols('a b c x')
     tsteqn = Equation(a, b/c)
@@ -162,3 +161,13 @@ def test_do_syntax():
     assert poly.dorhs.collect(x) == Eqn(poly.lhs, poly.rhs.collect(x))
     assert poly.dolhs.collect(x) == Eqn(poly.lhs.collect(x), poly.rhs)
     assert poly.do.collect(x) == Eqn(poly.lhs.collect(x), poly.rhs.collect(x))
+
+
+def test_rewrite_add():
+    b, x = symbols("x, b")
+    eq = Equation(x + b, x - b)
+    assert eq.rewrite(Add) == Equation(2 * b, 0)
+    assert set(eq.rewrite(Add, evaluate=None).lhs.args) == set((b, x, b, -x))
+    assert set(eq.rewrite(Add, evaluate=False).lhs.args) == set((b, x, b, -x))
+    assert eq.rewrite(Add, eqn=False) == 2 * b
+    assert set(eq.rewrite(Add, eqn=False, evaluate=False).args) == set((b, x, b, -x))

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -171,3 +171,24 @@ def test_rewrite_add():
     assert set(eq.rewrite(Add, evaluate=False).lhs.args) == set((b, x, b, -x))
     assert eq.rewrite(Add, eqn=False) == 2 * b
     assert set(eq.rewrite(Add, eqn=False, evaluate=False).args) == set((b, x, b, -x))
+
+
+def test_subs():
+    a, b, c, x = symbols('a b c x')
+    eq1 = Equation(x + a + b + c, x * a * b * c)
+    eq2 = Equation(x + a, 4)
+    assert eq1.subs(a, 2) == Equation(x + b + c + 2, 2 * x * b * c)
+    assert eq1.subs([(a, 2), (b, 3)]) == Equation(x + c + 5, 6 * x * c)
+    assert eq1.subs({a: 2, b: 3}) == Equation(x + c + 5, 6 * x * c)
+    assert eq1.subs(eq2) == Equation(4 + b + c, x * a * b * c)
+
+    # verify that substituting an Equation into an expression is not supported
+    raises(ValueError, lambda: eq1.dolhs.subs(eq2))
+    raises(ValueError, lambda: eq1.dorhs.subs(eq2))
+    raises(ValueError, lambda: (x + a + b + c).subs(eq2))
+
+    # verify the effectivness of `simultaneous`
+    eq = Equation((x + a) / a, b * c)
+    sd = {x + a: a, a: x + a}
+    assert eq.subs(sd) == Equation(1, b * c)
+    assert eq.subs(sd, simultaneous=True) == Equation(a / (x + a), b * c)

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -172,6 +172,11 @@ def test_subs():
     assert eq1.subs({a: 2, b: 3}) == Equation(x + c + 5, 6 * x * c)
     assert eq1.subs(eq2) == Equation(4 + b + c, x * a * b * c)
 
+    # verify that proper errors are raised
+    eq3 = Equation(b, 5)
+    raises(TypeError, lambda: eq1.subs([eq2, eq3]))
+    raises(ValueError, lambda: eq1.subs(eq2, {b: 5}))
+
     # verify that substituting an Equation into an expression is not supported
     raises(ValueError, lambda: eq1.dolhs.subs(eq2))
     raises(ValueError, lambda: eq1.dorhs.subs(eq2))

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -163,16 +163,6 @@ def test_do_syntax():
     assert poly.do.collect(x) == Eqn(poly.lhs.collect(x), poly.rhs.collect(x))
 
 
-def test_rewrite_add():
-    b, x = symbols("x, b")
-    eq = Equation(x + b, x - b)
-    assert eq.rewrite(Add) == Equation(2 * b, 0)
-    assert set(eq.rewrite(Add, evaluate=None).lhs.args) == set((b, x, b, -x))
-    assert set(eq.rewrite(Add, evaluate=False).lhs.args) == set((b, x, b, -x))
-    assert eq.rewrite(Add, eqn=False) == 2 * b
-    assert set(eq.rewrite(Add, eqn=False, evaluate=False).args) == set((b, x, b, -x))
-
-
 def test_subs():
     a, b, c, x = symbols('a b c x')
     eq1 = Equation(x + a + b + c, x * a * b * c)


### PR DESCRIPTION
Sometime it is useful to take one equation and substitute it into another one. For example:

```
eq1 = Equation(L1, R1)
eq2 = Equation(L2, R2)
eq1.subs(eq2)
```

The above code will look for L2 inside L1 and R1: if matches are found, they will be replaced
with R2. This feature is very important for this class to be used "naturally" and quickly.
The obvious alternative would be to execute:

```
eq1.subs(eq2.lhs, eq2.rhs)
```

which is fine if we are only doing one substitution once in a while, but become time consuming
when dealing with multiple equations and multiple substitutions.

Even though the best approach would be to tweak the `Basic` class to make it recognizes `Equation`,
at this point of development it is not worth the effort. For the time being it is better to get
`Equation` overrides the `subs` method in order to implement the new behaviour. If and when this
module will be merged into sympy, then editing `Basic.subs` will be trivial.
This means that substituting an equation into a symbolic expression will fail.