### PR TITLE
Fixed latex printer

### DIFF
--- a/algebra_with_sympy/algebraic_equation.py
+++ b/algebra_with_sympy/algebraic_equation.py
@@ -632,14 +632,14 @@ class Equation(Basic, EvalfMixin):
             return self.__str__()
         return repstr
 
-    def _latex(self, obj, **kwargs):
+    def _latex(self, printer):
         tempstr = ''
         if algwsym_config.output.show_code and not \
             algwsym_config.output.human_text:
             tempstr +='\\text{code version: '+ self.__repr__()+'} \\newline '
-        tempstr += latex(self.lhs, **kwargs)
+        tempstr += printer._print(self.lhs)
         tempstr += '='
-        tempstr += latex(self.rhs, **kwargs)
+        tempstr += printer._print(self.rhs)
         namestr = self._get_eqn_name()
         if namestr !='' and algwsym_config.output.label:
             tempstr += '\\,\\,\\,\\,\\,\\,\\,\\,\\,\\,'

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -1,6 +1,8 @@
 from sympy import symbols, integrate, simplify, expand, factor, Integral
 from sympy import diff, FiniteSet, Equality, Function, functions, Matrix, S
-from sympy import sin, cos, log, exp
+from sympy import sin, cos, log, exp, latex, Symbol
+from sympy.core.function import AppliedUndef
+from sympy.printing.latex import LatexPrinter
 from .algebraic_equation import solve, collect, Equation, Eqn, sqrt, root
 from .algebraic_equation import algwsym_config
 from .algebraic_equation import EqnFunction, str_to_extend_sympy_func
@@ -29,6 +31,20 @@ for func in ('sin', 'cos', 'log', 'exp'):
                 'properly with Equations. If you use it with Equations, ' \
                 'validate its behavior. We are working to address this ' \
                 'issue.')
+
+
+class CustomLatexPrinter(LatexPrinter):
+    """Print undefined applied functions without arguments"""
+    def _print_Function(self, expr, exp=None):
+        if isinstance(expr, AppliedUndef):
+            return self._print(Symbol(expr.func.__name__))
+        return super()._print_Function(expr, exp)
+
+
+def my_latex(expr, **settings):
+    """Mimic latex()"""
+    return CustomLatexPrinter(settings).doprint(expr)
+
 
 def test_define_equation():
     a, b, c = symbols('a b c')
@@ -84,7 +100,14 @@ def test_outputs():
     algwsym_config.output.human_text = True
     assert tsteqn.__repr__() == 'a = b/c'
     assert tsteqn.__str__() == 'a = b/c'
-    assert tsteqn._latex(tsteqn) == 'a=\\frac{b}{c}'
+    assert latex(tsteqn) == 'a=\\frac{b}{c}'
+
+    f = Function("f")(a, b, c)
+    eq = Eqn(f, 2)
+    assert latex(eq) == "f{\\left(a,b,c \\right)}=2"
+    # use custom printer
+    assert my_latex(eq) == "f=2"
+
 
 def test_sympy_functions():
     # TODO: To avoid problems if a function in sympy changes or is added this


### PR DESCRIPTION
The `_latex` method was implemented in a wrong way, which didn't allowed the use of a custom printer.
The capability to use custom printer is essential. Think for example to an equation containing multiple
undefined applied functions, `f(x, y, z), g(x, y, z), ...`. We quickly run out of display
space on a Jupyter Notebook cell because `(x, y, z)` is rendered multiple times. With a custom printer we
can easily hide these repetitions.

This PR implements the `def _latex(self, printer)` as pointed out in the documentation:
https://docs.sympy.org/latest/modules/printing.html

This way allows the use of a custom printer. Tests have been added to assert this behavior.