### PR TITLE
make solve returns solutions sorted according to the provided symbols

### DIFF
--- a/algebra_with_sympy/algebraic_equation.py
+++ b/algebra_with_sympy/algebraic_equation.py
@@ -658,6 +658,11 @@ def solve(f, *symbols, **flags):
             return solns[0]
         return solns
     else:
+        if len(solns) == 1:
+            # do not wrap a singleton in FiniteSet if it already is
+            for k in solns:
+                if isinstance(k, FiniteSet):
+                    return k
         return FiniteSet(*solns)
 
 def solveset(f, symbols, domain=sympy.Complexes):

--- a/algebra_with_sympy/algebraic_equation.py
+++ b/algebra_with_sympy/algebraic_equation.py
@@ -624,6 +624,8 @@ def solve(f, *symbols, **flags):
             newf.append(f)
     flags['dict'] = True
     result = solve(newf, *symbols, **flags)
+    if len(symbols) == 1 and hasattr(symbols[0], "__iter__"):
+        symbols = symbols[0]
     if contains_eqn:
         if len(result[0]) == 1:
             for k in result:
@@ -631,6 +633,9 @@ def solve(f, *symbols, **flags):
                     val = k[key]
                     tempeqn = Eqn(key, val)
                     solns.append(tempeqn)
+            if len(solns) == len(symbols):
+                # sort according to the user-provided symbols
+                solns = sorted(solns, key=lambda x: symbols.index(x.lhs))
         else:
             for k in result:
                 solnset = []
@@ -640,11 +645,18 @@ def solve(f, *symbols, **flags):
                     solnset.append(tempeqn)
                 if not algwsym_config.output.solve_to_list:
                     solnset = FiniteSet(*solnset)
+                else:
+                    if len(solnset) == len(symbols):
+                        # sort according to the user-provided symbols
+                        solnset = sorted(solnset, key=lambda x: symbols.index(x.lhs))
                 solns.append(solnset)
     else:
         solns = result
     if algwsym_config.output.solve_to_list:
-        return list(solns)
+        if len(solns) == 1 and hasattr(solns[0], "__iter__"):
+            # no need to wrap a list of a single element inside another list
+            return solns[0]
+        return solns
     else:
         return FiniteSet(*solns)
 

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -282,9 +282,9 @@ def test_solve():
     e1 = Eqn(Tp, pi / (wn*sqrt(1 - xi**2)))
     e2 = Eqn(Ts, 4 / (wn*xi))
     algwsym_config.output.solve_to_list = False
-    assert solve([e1, e2], [xi, wn]) == FiniteSet(FiniteSet(
+    assert solve([e1, e2], [xi, wn]) == FiniteSet(
         Eqn(xi, 4*Tp/sqrt(16*Tp**2 + pi**2*Ts**2)),
-        Eqn(wn, sqrt(16*Tp**2 + pi**2*Ts**2)/(Tp*Ts))))
+        Eqn(wn, sqrt(16*Tp**2 + pi**2*Ts**2)/(Tp*Ts)))
     algwsym_config.output.solve_to_list = True
     assert solve([e1, e2], [xi, wn]) == [
         Eqn(xi, 4*Tp/sqrt(16*Tp**2 + pi**2*Ts**2)),

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -1,6 +1,6 @@
 from sympy import symbols, integrate, simplify, expand, factor, Integral, Add
 from sympy import diff, FiniteSet, Equation, Function, Matrix, S, Eq
-from sympy import sin, cos, log, exp, latex, Symbol, I
+from sympy import sin, cos, log, exp, latex, Symbol, I, pi
 from sympy.core.function import AppliedUndef
 from sympy.printing.latex import LatexPrinter
 from algebra_with_sympy.algebraic_equation import solve, collect
@@ -276,6 +276,25 @@ def test_solve():
                                       [Equation(x, -1), Equation(y, -1)],
                                       [Equation(x, 1), Equation(y, 1)],
                                       [Equation(x, 3), Equation(y, -3)]]
+    
+    xi, wn = symbols("xi omega_n", real=True, positive=True)
+    Tp, Ts = symbols("T_p, T_s", real=True, positive=True)
+    e1 = Eqn(Tp, pi / (wn*sqrt(1 - xi**2)))
+    e2 = Eqn(Ts, 4 / (wn*xi))
+    algwsym_config.output.solve_to_list = False
+    assert solve([e1, e2], [xi, wn]) == FiniteSet(FiniteSet(
+        Eqn(xi, 4*Tp/sqrt(16*Tp**2 + pi**2*Ts**2)),
+        Eqn(wn, sqrt(16*Tp**2 + pi**2*Ts**2)/(Tp*Ts))))
+    algwsym_config.output.solve_to_list = True
+    assert solve([e1, e2], [xi, wn]) == [
+        Eqn(xi, 4*Tp/sqrt(16*Tp**2 + pi**2*Ts**2)),
+        Eqn(wn, sqrt(16*Tp**2 + pi**2*Ts**2)/(Tp*Ts))
+    ]
+    # order of symbols are swapped -> results are swapped as well
+    assert solve([e1, e2], [wn, xi]) == [
+        Eqn(wn, sqrt(16*Tp**2 + pi**2*Ts**2)/(Tp*Ts)),
+        Eqn(xi, 4*Tp/sqrt(16*Tp**2 + pi**2*Ts**2))
+    ]
 
 def test_Heaviside():
     a, b, c, x = symbols('a b c x')


### PR DESCRIPTION
This PR solves Issue #27 .

```py
from sympy import *
from algebra_with_sympy import Eqn, solve, algwsym_config
algwsym_config.output.label = False
algwsym_config.output.solve_to_list = True
init_printing()

xi, wn = symbols("xi omega_n", real=True, positive=True)
Tp, Ts = symbols("T_p, T_s", real=True, positive=True)
e1 = Eqn(Tp, pi / (wn*sqrt(1 - xi**2)))
e2 = Eqn(Ts, 4 / (wn*xi))
display(e1, e2)
```
![image](https://github.com/gutow/Algebra_with_Sympy/assets/9921777/ab0e18ed-e3a1-47f8-b69a-edcd0f3bd69f)

```py
sol = solve([e1, e2], [wn, xi])
wn_eq, xi_eq = sol
display(sol, wn_eq, xi_eq)
```
![image](https://github.com/gutow/Algebra_with_Sympy/assets/9921777/6dee94bf-3d37-469c-a227-6895fa9c44bd)

And changing the order of the symbols I also get the expected results:

```py
sol = solve([e1, e2], [xi, wn])
xi_eq, wn_eq = sol
display(sol, xi_eq, wn_eq)
```
![image](https://github.com/gutow/Algebra_with_Sympy/assets/9921777/55bc1ef4-7a6b-453a-8081-7b96dd464093)




